### PR TITLE
Fixes Business Info scrape

### DIFF
--- a/src/commands/Info/stockcharts-info.ts
+++ b/src/commands/Info/stockcharts-info.ts
@@ -85,7 +85,7 @@ export const getSymbolInfo = async (ticker: string): Promise<TickerInfo> => got(
 export const getCompanyInfo = async (ticker: string): Promise<string> => {
   const result = await got(`https://finviz.com/quote.ashx?t=${encodeURIComponent(ticker)}`);
   const $ = cheerio.load(result.body);
-  return $('body > div:nth-child(8) > div > table:nth-child(3) > tbody > tr.table-light3-row > td').text();
+  return $('body > div:nth-child(9) > div > table:nth-child(3) > tbody > tr.table-light3-row > td').text();
 };
 
 export const getCompanyNews = async (ticker: string): Promise<string[]> => {


### PR DESCRIPTION
This fix updates the div:nth-child() from 8 to 9 to match the updates done to the website. This now properly scrapes the company info.
It's literally the only change so Tooters better not die again.
![tooter_Commit1](https://user-images.githubusercontent.com/7551867/152870058-507d4a01-90e4-4cfe-8fb6-9abd54bfc897.png)

