### PR TITLE
Add error catch to info command

### DIFF
--- a/src/commands/Info/info.ts
+++ b/src/commands/Info/info.ts
@@ -24,7 +24,13 @@ export const InfoCommand: ICommand = {
           { name: 'Summary', value: companyInfo.slice(0, 1024) },
         ],
       },
-    });
+    }).catch(error => {
+		   // Error 50035 corresponds to empty field being sent to channel
+		   if( error.code == 50035) {
+			    message.channel.send("Someone finally got off their ass and put in an error catch.\n\
+		      !info broke. Blank field returned. It'll get fixed soon.");
+		   }
+	  });
     return Promise.resolve();
   },
 };


### PR DESCRIPTION
Added error catch when returned field is blank. Usually means that FinViz changed their website structure (again).