### PR TITLE
Add ext price

### DIFF
--- a/src/commandlist.ts
+++ b/src/commandlist.ts
@@ -18,6 +18,7 @@ import { FACommand } from './commands/FA';
 
 import { FuckCommand, GapperCommand } from './commands/Fuck';
 import { CorrelationCommand, RealizedVolCommand } from './commands/market_dashboard';
+import { ExtendHoursCommand } from './commands/ExtendHours';
 
 export const commandList: ICommand[] = [
   FuturesCommand,
@@ -39,5 +40,6 @@ export const commandList: ICommand[] = [
   FACommand,
   FuckCommand,
   GapperCommand,
-  CorrelationCommand, RealizedVolCommand
+  CorrelationCommand, RealizedVolCommand,
+  ExtendHoursCommand
 ];

--- a/src/commands/ExtendHours/extendHours.ts
+++ b/src/commands/ExtendHours/extendHours.ts
@@ -1,0 +1,37 @@
+import { Message } from 'discord.js';
+
+import { ICommand } from '../../icommand';
+import { getSymbolInfo } from './stockcharts-ext';
+
+export const ExtendHoursCommand: ICommand = {
+  name: 'ExtendHours',
+  helpDescription: '!ext aapl',
+  showInHelp: true,
+  trigger: (msg: Message) => msg.content.startsWith('!ext'),
+  command: async (message: Message) => {
+    const ticker = message.content.replace('!ext', '').trim();
+    const price = await getSymbolInfo(ticker);
+	//const extendedHoursClose = price.exhours.close;
+	console.log(price.extendedHours)
+    message.channel.send({
+      embeds: [{
+        color: 3447003,
+        title: ticker.toUpperCase(),
+		description: 'Extended hours prices (for when FinViz stops tracking it)',
+        fields: [
+          { name: 'Price', value: price.extendedHours.close.toString(), inline: true },
+		  { name: '% Change', value: price.extendedHours.pctChg, inline: true },
+		  { name: 'Time', value: price.extendedHours.time, inline: true },
+        ],
+      },
+      ],
+    }).catch((error) => {
+		   // Error 50035 corresponds to empty field being sent to channel
+		   if (error.code == 50035) {
+			    message.channel.send("Someone finally got off their ass and put in an error catch.\n\
+		      !info broke. Blank field returned. It'll get fixed soon.");
+		   }
+	  });
+    return Promise.resolve();
+  },
+};

--- a/src/commands/ExtendHours/index.ts
+++ b/src/commands/ExtendHours/index.ts
@@ -1,0 +1,1 @@
+export { ExtendHoursCommand } from './extendHours';

--- a/src/commands/ExtendHours/stockcharts-ext.ts
+++ b/src/commands/ExtendHours/stockcharts-ext.ts
@@ -1,0 +1,18 @@
+import got from 'got';
+import * as cheerio from 'cheerio';
+
+export interface ext {
+  ExtendedHoursType: number;
+  chg: number;
+  pctChg: string;
+  time: string;
+  close: string;
+}
+
+export interface TickerInfo {
+  symbol: string;
+  latestTrade: string;
+  extendedHours: ext;
+}
+
+export const getSymbolInfo = async (ticker: string): Promise<TickerInfo> => got(`https://stockcharts.com/j-sum/sum?cmd=symsum&symbol=${encodeURIComponent(ticker)}`).json();


### PR DESCRIPTION
Adding !ext command to pull extended hours prices when FinViz stops tracking in pre-market and after market.