### PR TITLE
Add rrg command

### DIFF
--- a/src/commandlist.ts
+++ b/src/commandlist.ts
@@ -17,7 +17,7 @@ import { SQBestCommand, SQTickerCommand, SQWorstCommand } from './commands/sq';
 import { FACommand } from './commands/FA';
 
 import { FuckCommand, GapperCommand } from './commands/Fuck';
-import { CorrelationCommand, RealizedVolCommand } from './commands/market_dashboard';
+import { CorrelationCommand, RealizedVolCommand, RelRotGraphCommand } from './commands/market_dashboard';
 import { ExtendHoursCommand } from './commands/ExtendHours';
 
 export const commandList: ICommand[] = [

--- a/src/commands/market_dashboard/index.ts
+++ b/src/commands/market_dashboard/index.ts
@@ -1,1 +1,1 @@
-export { CorrelationCommand, RealizedVolCommand } from './market-dashboard';
+export { CorrelationCommand, RealizedVolCommand, RelRotGraphCommand } from './market-dashboard';

--- a/src/commands/market_dashboard/market-dashboard.ts
+++ b/src/commands/market_dashboard/market-dashboard.ts
@@ -70,3 +70,31 @@ export const RealizedVolCommand: ICommand = {
     return Promise.resolve();
   },
 };
+
+export const RelRotGraphCommand: ICommand = {
+  name: 'Relative Rotation Graphs',
+  helpDescription: '!rrg',
+  showInHelp: true,
+  trigger: (msg: Message) => msg.content.startsWith('!rrg'),
+  command: async (message: Message, services: any) => {
+  try
+  {
+    const image = await got(`${process.env.MARKET_DASHBOARD_URI}/RelativeRotGraph`);
+
+    await message.channel
+        .send(
+          {
+            files: [
+              image.rawBody,
+            ],
+          },
+        );
+  }
+  catch(e)
+  {
+    console.error(e);
+  }
+ 
+    return Promise.resolve();
+  },
+};


### PR DESCRIPTION
This "should" interface with the RelativeRotGraph.py script in the market-dashboard repo. The rrg script/command isn't setup for user defined inputs yet. 
(Didn't test this since it seemed like a simple enough change. Guess that means Tooters will def blow up after this commit is merged.)