### PR TITLE
Adding maxloss command

### DIFF
--- a/src/commandlist.ts
+++ b/src/commandlist.ts
@@ -24,7 +24,7 @@ import { WetGoodsCommand, TootersCommand, FlowinCommand, DanglingCommand, Netbus
 import { PotyCommand, PotyPassive, ToalyCommand, FreelanceCommand, AbeCommand, HitManCommand } from './commands/Fuck';
 import { CorrelationCommand, RealizedVolCommand, RelRotGraphCommand, DressingCommand } from './commands/market_dashboard';
 import { VolConeCommand, PairsCommand, CoTCommand, VixBinsCommand, RelChartCommand, VolSheetCommand } from './commands/market_dashboard';
-import { VixCurveCommand, MomoDashCommand } from './commands/market_dashboard';
+import { VixCurveCommand, MomoDashCommand, MaxLossCommand } from './commands/market_dashboard';
 import { ExtendHoursCommand } from './commands/ExtendHours';
 
 export const commandList: ICommand[] = [
@@ -58,6 +58,6 @@ export const commandList: ICommand[] = [
   ExtendHoursCommand, RelRotGraphCommand,
   DressingCommand, VolConeCommand,
   PairsCommand, CoTCommand, VixBinsCommand,
-  VolSheetCommand, MomoDashCommand,
+  VolSheetCommand, MomoDashCommand, MaxLossCommand,
   RelChartCommand, VixCurveCommand,
 ];

--- a/src/commands/market_dashboard/index.ts
+++ b/src/commands/market_dashboard/index.ts
@@ -1,4 +1,4 @@
 export { CorrelationCommand, RealizedVolCommand, RelRotGraphCommand } from './market-dashboard';
 export { DressingCommand, VolConeCommand, PairsCommand, CoTCommand, VixBinsCommand  } from './market-dashboard';
-export { VolSheetCommand, MomoDashCommand } from './market-dashboard';
+export { VolSheetCommand, MomoDashCommand, MaxLossCommand } from './market-dashboard';
 export { RelChartCommand, VixCurveCommand  } from './market-dashboard';

--- a/src/commands/market_dashboard/market-dashboard.ts
+++ b/src/commands/market_dashboard/market-dashboard.ts
@@ -523,3 +523,38 @@ export const MomoDashCommand: ICommand = {
     return Promise.resolve();
   },
 };
+
+export const MaxLossCommand: ICommand = {
+  name: 'StdDev price based on 1-yr history',
+  helpDescription: '!maxloss [ticker]',
+  showInHelp: true,
+  trigger: (msg: Message) => msg.content.startsWith('!maxloss'),
+  command: async (message: Message, services: any) => {
+  let ticker = "AAPL";
+  const args = message.content.toLowerCase().split(' ');
+  if(args.length == 2)
+  {
+    ticker = args[1];
+  }
+  try{
+    const image = await got(`${process.env.MARKET_DASHBOARD_URI}/maxloss/${ticker}`);
+	if(image.body === 'null') {
+		await message.reply("Invalid ticker you jerk.")
+	} else {
+		await message.channel
+		  .send(
+			{
+			  files: [
+				image.rawBody,
+			  ],
+			},
+		  );
+	}  
+  } catch(e)
+  {
+    console.error(e);
+    return Promise.resolve();
+  }
+    return Promise.resolve();
+  },
+};


### PR DESCRIPTION
Generates historical rolling annual zscores of price for a ticker. Shows the current one year zscore history and projected prices based on some zscore values. Idea sprung from selling calls on levered ETFs and not knowing what a reasonable max pain/loss would be.